### PR TITLE
Fix server shutdown process and backup manager wrapper script

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,7 +48,6 @@ do
     echo_info "> Server main thread started with pid ${killpid}"
     wait ${killpid}
 
-    send_stop_notification
 
     # Wait for backup jobs to finish
     mapfile -t backup_pids < <(pgrep backup)

--- a/includes/config.sh
+++ b/includes/config.sh
@@ -321,8 +321,8 @@ function setup_rcon_yaml () {
         if [[ "${SERVER_SETTINGS_MODE,,}" == "auto" ]]; then
             # Use environment variables
             echo_warning ">> Using environment variables to configure 'rcon.yaml' config file."
-            echo_info -n "> Admin Password: " && echo_base "$RCON_PORT"
-            echo_info -n "> RCON Port: " && echo_base "$rcon_port"
+            echo_info -n "> Admin Password: " && echo_base "$ADMIN_PASSWORD"
+            echo_info -n "> RCON Port: " && echo_base "$RCON_PORT"
             
             if [[ -n ${RCON_PORT+x} ]]; then
                 sed -i "s/###RCON_PORT###/$RCON_PORT/" "$RCON_CONFIG_FILE"

--- a/includes/rcon.sh
+++ b/includes/rcon.sh
@@ -8,9 +8,15 @@ function rcon_broadcast_save_and_shutdown() {
     rconcli 'broadcast Saving-before-shutdown...'
     rconcli 'save'
     rconcli 'broadcast Saving-done'
-    rconcli 'broadcast Server-shutting-down...'
-    sleep 5
+
+    backupmanager create
+    
+    sleep 1
+    rconcli "broadcast Server-is-shutting-down-now!"
+    sleep 1
+    rconcli "shutdown 1"
 }
+
 # AUTO_RESTART_WARN_MINUTES or AUTO_UPDATE_WARN_MINUTES
 function rcon_broadcast_restart() {
     local restart_warn_minutes=${1}

--- a/includes/server.sh
+++ b/includes/server.sh
@@ -79,12 +79,9 @@ function start_server() {
 function stop_server() {
     echo_warning ">>> Stopping server..."
 
-    rcon_broadcast_save_and_shutdown
-
     send_stop_notification
-
-	kill -SIGTERM "$(pidof PalServer-Linux-Test)"
-	tail --pid="$(pidof PalServer-Linux-Test)" -f 2>/dev/null
+    
+    rcon_broadcast_save_and_shutdown
 }
 
 # Function to restart the gameserver

--- a/scripts/wrappers/backupmanager_cli.sh
+++ b/scripts/wrappers/backupmanager_cli.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# Wrapper for backup manager for cli usage
+# Wrapper for backup manager for CLI usage
 # Makes the usage easier when running the backup manager from the command line
-# Usage is supposes to be 'backup [option] [arguments]'
+# Usage is supposed to be 'backup [option] [arguments]'
 
-backupmanager "$@"
+# Use eval to correctly handle argument passing
+su steam -c "eval backupmanager $*" -- 


### PR DESCRIPTION
This pull request includes the following changes:

- Remove unnecessary function call in entrypoint.sh

- Fix rcon configuration log

- Refactor server shutdown process when docker restarts/stops for graceful exit

- Fix CLI usage in backupmanager wrapper script to enforce steam user